### PR TITLE
Usunięcie czasownika

### DIFF
--- a/revolver/data/words.json
+++ b/revolver/data/words.json
@@ -567,7 +567,6 @@
     "kolej",
     "deszcz",
     "cel",
-    "pchać",
     "kwartał",
     "kwarc",
     "królowa",


### PR DESCRIPTION
Usunięcie czasownika "pchać".